### PR TITLE
Cancel image loading requests when cells are reused

### DIFF
--- a/Cineaste/Networking/Webservice.swift
+++ b/Cineaste/Networking/Webservice.swift
@@ -16,18 +16,20 @@ enum NetworkError: Error {
 }
 
 final class Webservice {
-    static func load<A>(resource: Resource<A>?, completion: @escaping (Result<A>) -> Void) {
+    @discardableResult
+    static func load<A>(resource: Resource<A>?, completion: @escaping (Result<A>) -> Void) -> URLSessionTask? {
         guard let resource = resource else {
             completion(Result.error(NetworkError.emptyResource))
-            return
+            return nil
         }
         guard let url = URL(string: resource.url) else {
             completion(Result.error(NetworkError.parseUrl))
-            return
+            return nil
         }
         var request = URLRequest(url: url)
         request.httpMethod = resource.method.rawValue
-        URLSession.shared.dataTask(with: request) { data, _, error in
+
+        let task = URLSession.shared.dataTask(with: request) { data, _, error in
             guard error == nil, let data = data else {
                 // swiftlint:disable:next force_unwrapping
                 completion(Result.error(error!))
@@ -38,6 +40,9 @@ final class Webservice {
                 return
             }
             completion(Result.success(result))
-        }.resume()
+        }
+
+        task.resume()
+        return task
     }
 }

--- a/Cineaste/ViewController/SearchMovies/SearchMoviesCell.swift
+++ b/Cineaste/ViewController/SearchMovies/SearchMoviesCell.swift
@@ -16,6 +16,7 @@ class SearchMoviesCell: UITableViewCell {
     static let identifier = "SearchMoviesCell"
 
     weak var delegate: SearchMoviesCellDelegate?
+    private weak var posterLoadingTask: URLSessionTask?
     var movie: Movie? {
         didSet {
             if let movie = movie {
@@ -64,7 +65,7 @@ class SearchMoviesCell: UITableViewCell {
         poster.image = UIImage.posterPlaceholder
 
         guard let posterPath = movie.posterPath else { return }
-        Webservice.load(resource: Movie.loadPoster(from: posterPath)) { result in
+        posterLoadingTask = Webservice.load(resource: Movie.loadPoster(from: posterPath)) { result in
             guard case let .success(poster) = result else {
                 return
             }
@@ -74,5 +75,11 @@ class SearchMoviesCell: UITableViewCell {
                 self.poster.image = poster
             }
         }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        posterLoadingTask?.cancel()
+        poster.image = UIImage.posterPlaceholder
     }
 }

--- a/Cineaste/ViewController/SearchMovies/SearchMoviesCell.swift
+++ b/Cineaste/ViewController/SearchMovies/SearchMoviesCell.swift
@@ -66,6 +66,7 @@ class SearchMoviesCell: UITableViewCell {
 
         guard let posterPath = movie.posterPath else { return }
         posterLoadingTask = Webservice.load(resource: Movie.loadPoster(from: posterPath)) { result in
+            self.posterLoadingTask = nil
             guard case let .success(poster) = result else {
                 return
             }

--- a/Cineaste/ViewController/SearchMovies/SearchMoviesCell.swift
+++ b/Cineaste/ViewController/SearchMovies/SearchMoviesCell.swift
@@ -80,6 +80,5 @@ class SearchMoviesCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         posterLoadingTask?.cancel()
-        poster.image = UIImage.posterPlaceholder
     }
 }


### PR DESCRIPTION
## Description

(Fixes #39)

This pull request adds a `prepareForReuse` block to the `SearchMoviesCell`, cancelling pending image loading requests.

To implement this, the `Webservice` now returns the `URLSessionTask` as a means to cancel tasks.