### PR TITLE
Add SearchController in MovieLists to search for a movie

### DIFF
--- a/Cineaste.xcodeproj/project.pbxproj
+++ b/Cineaste.xcodeproj/project.pbxproj
@@ -66,6 +66,12 @@
 		3F9806382055250F00B92A27 /* String+Cineaste.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9806372055250F00B92A27 /* String+Cineaste.swift */; };
 		3F98063A20554AE400B92A27 /* ShortcutIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F98063920554AE300B92A27 /* ShortcutIdentifier.swift */; };
 		3F98063D20556EA700B92A27 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3F98063F20556EA700B92A27 /* InfoPlist.strings */; };
+		3FA48F9F20FA7C14002F7665 /* SearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA48F9E20FA7C14002F7665 /* SearchController.swift */; };
+		3FA48FA020FA7C14002F7665 /* SearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA48F9E20FA7C14002F7665 /* SearchController.swift */; };
+		3FA48FA220FA856E002F7665 /* MoviesViewController+SearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA48FA120FA856E002F7665 /* MoviesViewController+SearchController.swift */; };
+		3FA48FA320FA856E002F7665 /* MoviesViewController+SearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA48FA120FA856E002F7665 /* MoviesViewController+SearchController.swift */; };
+		3FA48FA520FA859E002F7665 /* MoviesViewController+3DTouch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA48FA420FA859E002F7665 /* MoviesViewController+3DTouch.swift */; };
+		3FA48FA620FA859E002F7665 /* MoviesViewController+3DTouch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA48FA420FA859E002F7665 /* MoviesViewController+3DTouch.swift */; };
 		3FA6C9D820F7B5990050368E /* SafariViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6C9D720F7B5990050368E /* SafariViewController.swift */; };
 		3FA6C9D920F7DCEC0050368E /* SafariViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6C9D720F7B5990050368E /* SafariViewController.swift */; };
 		3FA808CF20027AF60036357B /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA808CE20027AF60036357B /* Button.swift */; };
@@ -280,6 +286,9 @@
 		3F9806372055250F00B92A27 /* String+Cineaste.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Cineaste.swift"; sourceTree = "<group>"; };
 		3F98063920554AE300B92A27 /* ShortcutIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutIdentifier.swift; sourceTree = "<group>"; };
 		3F98063E20556EA700B92A27 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		3FA48F9E20FA7C14002F7665 /* SearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchController.swift; sourceTree = "<group>"; };
+		3FA48FA120FA856E002F7665 /* MoviesViewController+SearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MoviesViewController+SearchController.swift"; sourceTree = "<group>"; };
+		3FA48FA420FA859E002F7665 /* MoviesViewController+3DTouch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MoviesViewController+3DTouch.swift"; sourceTree = "<group>"; };
 		3FA6C9D720F7B5990050368E /* SafariViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariViewController.swift; sourceTree = "<group>"; };
 		3FA808CE20027AF60036357B /* Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
 		3FA808D0200285590036357B /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
@@ -403,6 +412,7 @@
 				3F71F684200292B700496E05 /* TextView.swift */,
 				3FC95B8F207BF60700B44C84 /* OrangeNavigationController.swift */,
 				3FA6C9D720F7B5990050368E /* SafariViewController.swift */,
+				3FA48F9E20FA7C14002F7665 /* SearchController.swift */,
 			);
 			path = "Custom UI";
 			sourceTree = "<group>";
@@ -481,6 +491,8 @@
 			children = (
 				3F8644A81FFA69E70046114A /* MoviesViewController.swift */,
 				3FD2F87C201E04AD003B880E /* MoviesViewController+SwipeAction.swift */,
+				3FA48FA420FA859E002F7665 /* MoviesViewController+3DTouch.swift */,
+				3FA48FA120FA856E002F7665 /* MoviesViewController+SearchController.swift */,
 				3F1292F91FD7CC1100ED5593 /* MovieListCell.swift */,
 				3FAAD61920A6E5EE001A19D2 /* SeenMovieCell.swift */,
 			);
@@ -1049,6 +1061,7 @@
 			files = (
 				3FF790E620DE274A007B7D37 /* Instantiable.swift in Sources */,
 				3FF790E720DE274A007B7D37 /* Appearance.swift in Sources */,
+				3FA48FA320FA856E002F7665 /* MoviesViewController+SearchController.swift in Sources */,
 				3FF790E820DE274A007B7D37 /* Config.swift in Sources */,
 				3FA6C9D920F7DCEC0050368E /* SafariViewController.swift in Sources */,
 				3FF790E920DE274A007B7D37 /* PagedMovieResult.swift in Sources */,
@@ -1074,6 +1087,7 @@
 				3FF790FA20DE274A007B7D37 /* Label.swift in Sources */,
 				3FF790FB20DE274A007B7D37 /* NearbyMovie.swift in Sources */,
 				3FF790FC20DE274A007B7D37 /* SearchMoviesViewController+UITableView.swift in Sources */,
+				3FA48FA020FA7C14002F7665 /* SearchController.swift in Sources */,
 				3FF790FD20DE274A007B7D37 /* String+VariantFittingPresentationWidth.swift in Sources */,
 				3FF790FE20DE274A007B7D37 /* Decimal+Formatter.swift in Sources */,
 				3FF790FF20DE274A007B7D37 /* Resource.swift in Sources */,
@@ -1107,6 +1121,7 @@
 				3F7ABD5420F5C70C004B069E /* Movie+Formatted.swift in Sources */,
 				3FF7911B20DE274A007B7D37 /* ImportExportObject.swift in Sources */,
 				3FF7911C20DE274A007B7D37 /* String+DateFormatter.swift in Sources */,
+				3FA48FA620FA859E002F7665 /* MoviesViewController+3DTouch.swift in Sources */,
 				3FF7911D20DE274A007B7D37 /* MoviesViewController.swift in Sources */,
 				3F7ABD5220F5C704004B069E /* StoredMovie+Networking.swift in Sources */,
 				3FF7911E20DE274A007B7D37 /* MovieDetailType.swift in Sources */,
@@ -1123,6 +1138,7 @@
 			files = (
 				3F83BE781FF39DFC00E584E9 /* Instantiable.swift in Sources */,
 				3FD886461FF2C46400A86ACF /* Appearance.swift in Sources */,
+				3FA48FA220FA856E002F7665 /* MoviesViewController+SearchController.swift in Sources */,
 				953182F7203E17AF00A331A0 /* Config.swift in Sources */,
 				95F0DBC91F9D2CF9004681C7 /* PagedMovieResult.swift in Sources */,
 				3FCC71371FD7536B00A47ADF /* FetchedResultsManagerDelegate.swift in Sources */,
@@ -1148,6 +1164,7 @@
 				3FD722CC20264B720046DEAC /* SearchMoviesViewController+UITableView.swift in Sources */,
 				3F0178F920CD26DC00600DB4 /* String+VariantFittingPresentationWidth.swift in Sources */,
 				3FAA3BBA2082668900726DE2 /* Decimal+Formatter.swift in Sources */,
+				3FA48F9F20FA7C14002F7665 /* SearchController.swift in Sources */,
 				95EFA4B01FA13AAA004F1F94 /* Resource.swift in Sources */,
 				95D32F641F9AA2EA00497ED2 /* ApiKeyStore.swift in Sources */,
 				9526A70520448940004E08F7 /* MovieMatchViewController.swift in Sources */,
@@ -1181,6 +1198,7 @@
 				3FCC71331FD747D600A47ADF /* FetchedResultsManager.swift in Sources */,
 				3F5E0D8C20308FF700E091BE /* SettingsViewController.swift in Sources */,
 				3FE49554209DD33A006CD0D3 /* ImportExportObject.swift in Sources */,
+				3FA48FA520FA859E002F7665 /* MoviesViewController+3DTouch.swift in Sources */,
 				3F3BC2611FF40387000C7EC7 /* String+DateFormatter.swift in Sources */,
 				3F8644A91FFA69E70046114A /* MoviesViewController.swift in Sources */,
 				3F941B7320F52905008A4407 /* StoredMovie+Networking.swift in Sources */,

--- a/Cineaste/Custom UI/Appearance.swift
+++ b/Cineaste/Custom UI/Appearance.swift
@@ -24,17 +24,21 @@ extension UIColor {
 
 enum Appearance {
     static func setup() {
+        let whiteTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.basicWhite]
+        let darkTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.basicBackground]
+
         let navigationBar = UINavigationBar.appearance()
         navigationBar.tintColor = .primaryOrange
+
+        if #available(iOS 11.0, *) {
+            navigationBar.largeTitleTextAttributes = whiteTextAttributes
+        }
 
         let tabBar = UITabBar.appearance()
         tabBar.isTranslucent = false
         tabBar.tintColor = .basicWhite
         tabBar.barTintColor = .primaryOrange
         tabBar.unselectedItemTintColor = .basicBackground
-
-        let whiteTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.basicWhite]
-        let darkTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.basicBackground]
 
         let tabBarItem = UITabBarItem.appearance()
         tabBarItem.setTitleTextAttributes(whiteTextAttributes, for: .selected)

--- a/Cineaste/Custom UI/OrangeNavigationController.swift
+++ b/Cineaste/Custom UI/OrangeNavigationController.swift
@@ -13,10 +13,17 @@ class OrangeNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.backgroundColor = .basicWhite
+
         navigationBar.isTranslucent = false
         navigationBar.barTintColor = .primaryOrange
         navigationBar.tintColor = .basicWhite
         navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor: UIColor.basicWhite]
+
+        if #available(iOS 11.0, *) {
+            navigationItem.largeTitleDisplayMode = .automatic
+            navigationBar.prefersLargeTitles = true
+        }
     }
 
 }

--- a/Cineaste/Custom UI/SearchController.swift
+++ b/Cineaste/Custom UI/SearchController.swift
@@ -1,0 +1,40 @@
+//
+//  SearchController.swift
+//  Cineaste
+//
+//  Created by Felizia Bernutz on 14.07.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import UIKit
+
+public class SearchController: UISearchController {
+    public override init(searchResultsController: UIViewController?) {
+        super.init(searchResultsController: searchResultsController)
+
+        setup()
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
+    func setup() {
+        obscuresBackgroundDuringPresentation = false
+        isActive = false
+        searchBar.sizeToFit()
+
+        if #available(iOS 11.0, *) {
+            guard let textfield = searchBar.value(forKey: "searchField") as? UITextField,
+                let backgroundview = textfield.subviews.first else { return }
+            backgroundview.backgroundColor = .basicWhite
+            backgroundview.layer.cornerRadius = 10
+            backgroundview.clipsToBounds = true
+        }
+    }
+
+}

--- a/Cineaste/Storyboards/Base.lproj/MoviesList.storyboard
+++ b/Cineaste/Storyboards/Base.lproj/MoviesList.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Jd8-kw-QKP">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Jd8-kw-QKP">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -40,22 +40,16 @@
         <!--Movies View Controller-->
         <scene sceneID="ls7-06-u9J">
             <objects>
-                <viewController storyboardIdentifier="MoviesViewController" id="B9b-Vg-V1Y" customClass="MoviesViewController" customModule="Cineaste" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MoviesViewController" id="B9b-Vg-V1Y" customClass="MoviesViewController" customModule="Cineaste_App" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Rgb-8l-lc2">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bGK-kG-Gg1">
-                                <rect key="frame" x="166.5" y="355.5" width="42" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="xt5-ya-K37">
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="MovieListCell" rowHeight="100" id="hAp-6w-ts1" userLabel="MyMovieListCell" customClass="MovieListCell" customModule="Cineaste" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="MovieListCell" rowHeight="100" id="hAp-6w-ts1" userLabel="MyMovieListCell" customClass="MovieListCell" customModule="Cineaste_App" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hAp-6w-ts1" id="dde-eg-AiL">
@@ -68,7 +62,7 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="SPf-Nf-Irt">
                                                             <rect key="frame" x="0.0" y="0.0" width="260.5" height="62.5"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="wantToSee.title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yp2-e5-kUz" customClass="TitleLabel" customModule="Cineaste" customModuleProvider="target">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="wantToSee.title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yp2-e5-kUz" customClass="TitleLabel" customModule="Cineaste_App" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="0.0" width="260.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
@@ -87,7 +81,7 @@
                                                                                         <constraint firstAttribute="width" secondItem="hVu-j7-jUa" secondAttribute="height" id="fxH-yl-bOt"/>
                                                                                     </constraints>
                                                                                 </imageView>
-                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="wantToSee.runtime" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oyL-mH-45r" customClass="DescriptionLabel" customModule="Cineaste" customModuleProvider="target">
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="wantToSee.runtime" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oyL-mH-45r" customClass="DescriptionLabel" customModule="Cineaste_App" customModuleProvider="target">
                                                                                     <rect key="frame" x="18" y="0.0" width="108.5" height="13"/>
                                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                                     <nil key="textColor"/>
@@ -105,7 +99,7 @@
                                                                                         <constraint firstAttribute="width" constant="13" id="eTS-Q5-2df"/>
                                                                                     </constraints>
                                                                                 </imageView>
-                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="wantToSee.release" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-in-3iS" customClass="DescriptionLabel" customModule="Cineaste" customModuleProvider="target">
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="wantToSee.release" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-in-3iS" customClass="DescriptionLabel" customModule="Cineaste_App" customModuleProvider="target">
                                                                                     <rect key="frame" x="18.5" y="0.0" width="108" height="13"/>
                                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                                     <nil key="textColor"/>
@@ -125,7 +119,7 @@
                                                                                 <constraint firstAttribute="width" constant="13" id="vpn-CF-k32"/>
                                                                             </constraints>
                                                                         </imageView>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="wantToSee.votes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="60o-nb-3nP" customClass="DescriptionLabel" customModule="Cineaste" customModuleProvider="target">
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="wantToSee.votes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="60o-nb-3nP" customClass="DescriptionLabel" customModule="Cineaste_App" customModuleProvider="target">
                                                                             <rect key="frame" x="18" y="0.0" width="242.5" height="13"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <nil key="textColor"/>
@@ -181,7 +175,7 @@
                                             <outlet property="votes" destination="60o-nb-3nP" id="dKl-8s-T0s"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SeenMovieCell" rowHeight="100" id="fni-aC-e7v" userLabel="MyMovieListCell" customClass="SeenMovieCell" customModule="Cineaste" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SeenMovieCell" rowHeight="100" id="fni-aC-e7v" userLabel="MyMovieListCell" customClass="SeenMovieCell" customModule="Cineaste_App" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="128" width="375" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fni-aC-e7v" id="qmy-Bu-a98">
@@ -194,7 +188,7 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="o85-Dk-25Y">
                                                             <rect key="frame" x="0.0" y="0.0" width="260.5" height="41.5"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="seen.title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xyx-1d-0dG" customClass="TitleLabel" customModule="Cineaste" customModuleProvider="target">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="seen.title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xyx-1d-0dG" customClass="TitleLabel" customModule="Cineaste_App" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="0.0" width="70" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
@@ -210,7 +204,7 @@
                                                                                 <constraint firstAttribute="width" constant="13" id="yBx-g9-Vax"/>
                                                                             </constraints>
                                                                         </imageView>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="seen.watchedDate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jt2-wC-VaF" customClass="DescriptionLabel" customModule="Cineaste" customModuleProvider="target">
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="seen.watchedDate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jt2-wC-VaF" customClass="DescriptionLabel" customModule="Cineaste_App" customModuleProvider="target">
                                                                             <rect key="frame" x="18" y="0.0" width="127" height="13"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <nil key="textColor"/>
@@ -272,11 +266,7 @@
                         <constraints>
                             <constraint firstItem="xt5-ya-K37" firstAttribute="trailing" secondItem="u7c-Dj-4pb" secondAttribute="trailing" id="3CD-8A-XsK"/>
                             <constraint firstItem="xt5-ya-K37" firstAttribute="leading" secondItem="u7c-Dj-4pb" secondAttribute="leading" id="ApK-1B-XmR"/>
-                            <constraint firstItem="bGK-kG-Gg1" firstAttribute="left" relation="greaterThanOrEqual" secondItem="u7c-Dj-4pb" secondAttribute="left" constant="20" id="K8h-T8-S9V"/>
-                            <constraint firstItem="bGK-kG-Gg1" firstAttribute="centerY" secondItem="u7c-Dj-4pb" secondAttribute="centerY" id="NGb-k8-cmj"/>
                             <constraint firstItem="xt5-ya-K37" firstAttribute="bottom" secondItem="u7c-Dj-4pb" secondAttribute="bottom" id="eb0-ZW-YKE"/>
-                            <constraint firstItem="u7c-Dj-4pb" firstAttribute="right" relation="greaterThanOrEqual" secondItem="bGK-kG-Gg1" secondAttribute="right" constant="20" id="huk-jb-eEN"/>
-                            <constraint firstItem="bGK-kG-Gg1" firstAttribute="centerX" secondItem="u7c-Dj-4pb" secondAttribute="centerX" id="jo5-3I-Wfe"/>
                             <constraint firstItem="xt5-ya-K37" firstAttribute="top" secondItem="u7c-Dj-4pb" secondAttribute="top" id="wmt-d4-aGf"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="u7c-Dj-4pb"/>
@@ -298,6 +288,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="emptyListLabel" destination="bGK-kG-Gg1" id="KTZ-QA-PXo"/>
+                        <outlet property="emptyView" destination="lwS-UM-Evo" id="zqz-MP-TYM"/>
                         <outlet property="myMoviesTableView" destination="xt5-ya-K37" id="XQ7-My-Mne"/>
                         <segue destination="mxJ-DZ-Bxk" kind="presentation" identifier="ShowSearchFromMovieList" id="Mf1-Xj-P5J"/>
                         <segue destination="NMk-QO-vK8" kind="show" identifier="ShowMovieDetailSegue" id="ja9-hr-OdI"/>
@@ -305,6 +296,25 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8Np-YM-7eb" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <view contentMode="scaleToFill" id="lwS-UM-Evo">
+                    <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bGK-kG-Gg1" customClass="TitleLabel" customModule="Cineaste_App" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="CT1-LR-5rS" firstAttribute="trailing" secondItem="bGK-kG-Gg1" secondAttribute="trailing" id="6HD-Zy-xkV"/>
+                        <constraint firstItem="bGK-kG-Gg1" firstAttribute="leading" secondItem="CT1-LR-5rS" secondAttribute="leading" id="Ywh-r9-G0b"/>
+                        <constraint firstItem="bGK-kG-Gg1" firstAttribute="top" secondItem="CT1-LR-5rS" secondAttribute="top" id="l6y-fI-gdM"/>
+                        <constraint firstItem="CT1-LR-5rS" firstAttribute="bottom" secondItem="bGK-kG-Gg1" secondAttribute="bottom" id="t0y-pv-Y5W"/>
+                    </constraints>
+                    <viewLayoutGuide key="safeArea" id="CT1-LR-5rS"/>
+                </view>
             </objects>
             <point key="canvasLocation" x="2448.8000000000002" y="-1160.8695652173915"/>
         </scene>

--- a/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
+++ b/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
@@ -30,21 +30,9 @@ class MovieDetailViewController: UIViewController {
     }
 
     @IBOutlet var moreInformationButton: ActionButton!
-    @IBOutlet weak fileprivate var seenButton: ActionButton! {
-        didSet {
-            seenButton.setTitle(String.seen, for: .normal)
-        }
-    }
-    @IBOutlet weak fileprivate var mustSeeButton: ActionButton! {
-        didSet {
-            mustSeeButton.setTitle(String.wantToSee, for: .normal)
-        }
-    }
-    @IBOutlet var deleteButton: ActionButton! {
-        didSet {
-            deleteButton.setTitle(String.deleteActionLong, for: .normal)
-        }
-    }
+    @IBOutlet var seenButton: ActionButton!
+    @IBOutlet var mustSeeButton: ActionButton!
+    @IBOutlet var deleteButton: ActionButton!
 
     @IBOutlet weak fileprivate var descriptionTextView: UITextView! {
         didSet {
@@ -82,6 +70,7 @@ class MovieDetailViewController: UIViewController {
         super.viewDidLoad()
 
         updateDetail(for: type)
+        setupLocalization()
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action,
                                                             target: self,
@@ -167,6 +156,12 @@ class MovieDetailViewController: UIViewController {
     }
 
     // MARK: - Private
+
+    fileprivate func setupLocalization() {
+        seenButton.setTitle(String.seen, for: .normal)
+        mustSeeButton.setTitle(String.wantToSee, for: .normal)
+        deleteButton.setTitle(String.deleteActionLong, for: .normal)
+    }
 
     fileprivate func generateMovieURL() -> URL? {
         var movieUrl = Config.Backend.shareMovieUrl

--- a/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
+++ b/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
@@ -69,6 +69,10 @@ class MovieDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        if #available(iOS 11.0, *) {
+            navigationItem.largeTitleDisplayMode = .never
+        }
+
         updateDetail(for: type)
         setupLocalization()
 

--- a/Cineaste/ViewController/MyMovies/MoviesViewController+3DTouch.swift
+++ b/Cineaste/ViewController/MyMovies/MoviesViewController+3DTouch.swift
@@ -1,0 +1,29 @@
+//
+//  MoviesViewController+3DTouch.swift
+//  Cineaste
+//
+//  Created by Felizia Bernutz on 14.07.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import UIKit
+
+extension MoviesViewController: UIViewControllerPreviewingDelegate {
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+        let detailVC = MovieDetailViewController.instantiate()
+        guard let path = myMoviesTableView.indexPathForRow(at: location),
+            let objects = fetchedResultsManager.controller?.fetchedObjects,
+            objects.count > path.row
+            else { return nil }
+
+        let movie = objects[path.row]
+        detailVC.storedMovie = movie
+        detailVC.storageManager = storageManager
+        detailVC.type = (category == MovieListCategory.seen) ? .seen : .wantToSee
+        return detailVC
+    }
+
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
+        navigationController?.pushViewController(viewControllerToCommit, animated: true)
+    }
+}

--- a/Cineaste/ViewController/MyMovies/MoviesViewController+SearchController.swift
+++ b/Cineaste/ViewController/MyMovies/MoviesViewController+SearchController.swift
@@ -1,0 +1,27 @@
+//
+//  MoviesViewController+SearchController.swift
+//  Cineaste
+//
+//  Created by Felizia Bernutz on 14.07.18.
+//  Copyright © 2018 notimeforthat.org. All rights reserved.
+//
+
+import UIKit
+
+extension MoviesViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        guard let searchText = searchController.searchBar.text else { return }
+
+        if !searchText.isEmpty {
+            let predicate = NSPredicate(format: "title contains[c] '\(searchText)'")
+
+            fetchedResultsManager.refetch(for: predicate) {
+                self.myMoviesTableView.reloadData()
+            }
+        } else {
+            fetchedResultsManager.refetch(for: category.predicate) {
+                self.myMoviesTableView.reloadData()
+            }
+        }
+    }
+}

--- a/Cineaste/ViewController/MyMovies/MoviesViewController+SearchController.swift
+++ b/Cineaste/ViewController/MyMovies/MoviesViewController+SearchController.swift
@@ -13,7 +13,7 @@ extension MoviesViewController: UISearchResultsUpdating {
         guard let searchText = searchController.searchBar.text else { return }
 
         if !searchText.isEmpty {
-            let predicate = NSPredicate(format: "title contains[c] '\(searchText)'")
+            let predicate = NSPredicate(format: "title contains[c] '\(searchText)' AND \(category.predicate)")
 
             fetchedResultsManager.refetch(for: predicate) {
                 self.myMoviesTableView.reloadData()

--- a/Cineaste/ViewController/MyMovies/MoviesViewController.swift
+++ b/Cineaste/ViewController/MyMovies/MoviesViewController.swift
@@ -29,7 +29,7 @@ class MoviesViewController: UIViewController {
         }
     }
 
-    lazy var resultSearchController: SearchController  = {
+    lazy var resultSearchController: SearchController = {
         let resultSearchController = SearchController(searchResultsController: nil)
         resultSearchController.searchResultsUpdater = self
         return resultSearchController

--- a/Cineaste/ViewController/MyMovies/MoviesViewController.swift
+++ b/Cineaste/ViewController/MyMovies/MoviesViewController.swift
@@ -29,7 +29,18 @@ class MoviesViewController: UIViewController {
         }
     }
 
-    @IBOutlet weak var emptyListLabel: UILabel!
+    lazy var resultSearchController: SearchController  = {
+        let resultSearchController = SearchController(searchResultsController: nil)
+        resultSearchController.searchResultsUpdater = self
+        return resultSearchController
+    }()
+
+    @IBOutlet var emptyView: UIView!
+    @IBOutlet var emptyListLabel: TitleLabel! {
+        didSet {
+            emptyListLabel.textColor = UIColor.basicWhite
+        }
+    }
     @IBOutlet var myMoviesTableView: UITableView! {
         didSet {
             myMoviesTableView.dataSource = self
@@ -40,6 +51,8 @@ class MoviesViewController: UIViewController {
 
             myMoviesTableView.rowHeight = UITableViewAutomaticDimension
             myMoviesTableView.estimatedRowHeight = 80
+
+            myMoviesTableView.backgroundView = emptyView
         }
     }
 
@@ -56,16 +69,49 @@ class MoviesViewController: UIViewController {
         fetchedResultsManager.delegate = self
         fetchedResultsManager.setup(with: category.predicate) {
             self.myMoviesTableView.reloadData()
-            self.hideTableView(self.fetchedResultsManager.controller?.fetchedObjects?.isEmpty)
+            self.showEmptyState(self.fetchedResultsManager.controller?.fetchedObjects?.isEmpty)
         }
 
         registerForPreviewing(with: self, sourceView: myMoviesTableView)
+
+        configureSearchController()
+    }
+
+    // MARK: - SearchController
+
+    func configureSearchController() {
+        if #available(iOS 11.0, *) {
+            navigationItem.searchController = resultSearchController
+            navigationItem.hidesSearchBarWhenScrolling = true
+        } else {
+            myMoviesTableView.tableHeaderView = resultSearchController.searchBar
+        }
+
+        definesPresentationContext = true
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        if #available(iOS 11.0, *) {
+            return
+        } else {
+            resultSearchController.searchBar.sizeToFit()
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        hideTableView(fetchedResultsManager.controller?.fetchedObjects?.isEmpty)
+        showEmptyState(fetchedResultsManager.controller?.fetchedObjects?.isEmpty)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        fetchedResultsManager.refetch(for: category.predicate) {
+            self.resultSearchController.isActive = false
+        }
     }
 
     // MARK: - Action
@@ -75,6 +121,46 @@ class MoviesViewController: UIViewController {
             showUsernameAlert()
         } else {
             self.performSegue(withIdentifier: Segue.showMovieNight.rawValue, sender: nil)
+        }
+    }
+
+    @IBAction func triggerSearchMovieAction(_ sender: UIBarButtonItem) {
+        perform(segue: .showSearchFromMovieList, sender: self)
+    }
+
+    func showEmptyState(_ isEmpty: Bool?, handler: (() -> Void)? = nil) {
+        let isEmpty = isEmpty ?? true
+
+        DispatchQueue.main.async {
+            UIView.animate(
+                withDuration: 0.2,
+                animations: {
+                    self.myMoviesTableView.backgroundView?.alpha = isEmpty ? 1 : 0
+                },
+                completion: { _ in
+                    self.myMoviesTableView.backgroundView?.isHidden = !isEmpty
+                    handler?()
+                })
+        }
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        switch Segue(initWith: segue) {
+        case .showSearchFromMovieList?:
+            let navigationVC = segue.destination as? UINavigationController
+            let vc = navigationVC?.viewControllers.first as? SearchMoviesViewController
+            vc?.storageManager = storageManager
+        case .showMovieDetail?:
+            let vc = segue.destination as? MovieDetailViewController
+            vc?.storedMovie = selectedMovie
+            vc?.storageManager = storageManager
+            vc?.type = (category == MovieListCategory.seen) ? .seen : .wantToSee
+        case .showMovieNight?:
+            let navigationVC = segue.destination as? UINavigationController
+            let vc = navigationVC?.viewControllers.first as? MovieNightViewController
+            vc?.storageManager = storageManager
+        default:
+            break
         }
     }
 
@@ -108,46 +194,6 @@ class MoviesViewController: UIViewController {
         })
 
         self.present(alert, animated: true)
-    }
-
-    @IBAction func triggerSearchMovieAction(_ sender: UIBarButtonItem) {
-        perform(segue: .showSearchFromMovieList, sender: self)
-    }
-
-    func hideTableView(_ isEmpty: Bool?, handler: (() -> Void)? = nil) {
-        let isEmpty = isEmpty ?? true
-
-        DispatchQueue.main.async {
-            UIView.animate(
-                withDuration: 0.2,
-                animations: {
-                    self.myMoviesTableView.alpha = isEmpty ? 0 : 1
-                },
-                completion: { _ in
-                    self.myMoviesTableView.isHidden = isEmpty
-                    handler?()
-                })
-        }
-    }
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        switch Segue(initWith: segue) {
-        case .showSearchFromMovieList?:
-            let navigationVC = segue.destination as? UINavigationController
-            let vc = navigationVC?.viewControllers.first as? SearchMoviesViewController
-            vc?.storageManager = storageManager
-        case .showMovieDetail?:
-            let vc = segue.destination as? MovieDetailViewController
-            vc?.storedMovie = selectedMovie
-            vc?.storageManager = storageManager
-            vc?.type = (category == MovieListCategory.seen) ? .seen : .wantToSee
-        case .showMovieNight?:
-            let navigationVC = segue.destination as? UINavigationController
-            let vc = navigationVC?.viewControllers.first as? MovieNightViewController
-            vc?.storageManager = storageManager
-        default:
-            break
-        }
     }
 
     private func updateShortcutItems() {
@@ -269,30 +315,8 @@ extension MoviesViewController: FetchedResultsManagerDelegate {
     }
     func endUpdate() {
         myMoviesTableView.endUpdates()
-        hideTableView(fetchedResultsManager.controller?.fetchedObjects?.isEmpty)
+        showEmptyState(fetchedResultsManager.controller?.fetchedObjects?.isEmpty)
         updateShortcutItems()
-    }
-}
-
-// MARK: - 3D Touch
-
-extension MoviesViewController: UIViewControllerPreviewingDelegate {
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        let detailVC = MovieDetailViewController.instantiate()
-        guard let path = myMoviesTableView.indexPathForRow(at: location),
-            let objects = fetchedResultsManager.controller?.fetchedObjects,
-            objects.count > path.row
-            else { return nil }
-
-        let movie = objects[path.row]
-        detailVC.storedMovie = movie
-        detailVC.storageManager = storageManager
-        detailVC.type = (category == MovieListCategory.seen) ? .seen : .wantToSee
-        return detailVC
-    }
-
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        navigationController?.pushViewController(viewControllerToCommit, animated: true)
     }
 }
 

--- a/Cineaste/ViewController/SearchMovies/SearchMoviesViewController.swift
+++ b/Cineaste/ViewController/SearchMovies/SearchMoviesViewController.swift
@@ -22,11 +22,8 @@ class SearchMoviesViewController: UIViewController {
 
     private var searchDelayTimer: Timer?
 
-    lazy var resultSearchController: UISearchController  = {
-        let resultSearchController = UISearchController(searchResultsController: nil)
-        resultSearchController.dimsBackgroundDuringPresentation = false
-        resultSearchController.isActive = false
-        resultSearchController.searchBar.sizeToFit()
+    lazy var resultSearchController: SearchController  = {
+        let resultSearchController = SearchController(searchResultsController: nil)
         resultSearchController.searchResultsUpdater = self
         return resultSearchController
     }()
@@ -93,13 +90,6 @@ class SearchMoviesViewController: UIViewController {
         if #available(iOS 11.0, *) {
             navigationItem.searchController = resultSearchController
             navigationItem.hidesSearchBarWhenScrolling = false
-
-            //add style for searchField - only in iOS 11
-            guard let textfield = resultSearchController.searchBar.value(forKey: "searchField") as? UITextField,
-                let backgroundview = textfield.subviews.first else { return }
-            backgroundview.backgroundColor = .basicWhite
-            backgroundview.layer.cornerRadius = 10
-            backgroundview.clipsToBounds = true
         } else {
             moviesTableView.tableHeaderView = resultSearchController.searchBar
         }

--- a/Cineaste/ViewController/SearchMovies/SearchMoviesViewController.swift
+++ b/Cineaste/ViewController/SearchMovies/SearchMoviesViewController.swift
@@ -45,6 +45,10 @@ class SearchMoviesViewController: UIViewController {
 
         self.view.backgroundColor = UIColor.basicBackground
 
+        if #available(iOS 11.0, *) {
+            navigationItem.largeTitleDisplayMode = .never
+        }
+
         loadRecent { [weak self] movies in
             self?.movies = movies
         }

--- a/Cineaste/ViewController/SearchMovies/SearchMoviesViewController.swift
+++ b/Cineaste/ViewController/SearchMovies/SearchMoviesViewController.swift
@@ -22,7 +22,7 @@ class SearchMoviesViewController: UIViewController {
 
     private var searchDelayTimer: Timer?
 
-    lazy var resultSearchController: SearchController  = {
+    lazy var resultSearchController: SearchController = {
         let resultSearchController = SearchController(searchResultsController: nil)
         resultSearchController.searchResultsUpdater = self
         return resultSearchController

--- a/Cineaste/ViewController/Settings/SettingsDetailViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsDetailViewController.swift
@@ -33,6 +33,10 @@ class SettingsDetailViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        if #available(iOS 11.0, *) {
+            navigationItem.largeTitleDisplayMode = .never
+        }
     }
 
     override func viewDidLayoutSubviews() {

--- a/CineasteTests/MoviesViewControllerTests.swift
+++ b/CineasteTests/MoviesViewControllerTests.swift
@@ -72,16 +72,18 @@ class MoviesViewControllerTests: XCTestCase {
     }
 
     func testEmptyListShouldHideTableView() {
-        moviesVC.hideTableView(nil) {
-            XCTAssertTrue(self.tableView.isHidden)
+        XCTAssertNotNil(tableView.backgroundView)
+
+        moviesVC.showEmptyState(nil) {
+            XCTAssertFalse(self.tableView.backgroundView!.isHidden)
         }
 
-        moviesVC.hideTableView(true) {
-            XCTAssertTrue(self.tableView.isHidden)
+        moviesVC.showEmptyState(true) {
+            XCTAssertFalse(self.tableView.backgroundView!.isHidden)
         }
 
-        moviesVC.hideTableView(false) {
-            XCTAssertFalse(self.tableView.isHidden)
+        moviesVC.showEmptyState(false) {
+            XCTAssertTrue(self.tableView.backgroundView!.isHidden)
         }
     }
 


### PR DESCRIPTION
There is now a `UISearchController` in both movie lists, where you can search for movie titles and the list will be filtered. The initial state of the viewControllers is that the search bar is hidden, when you start scrolling down, it will appear and you can start a search. 

* Add a custom `SearchController` class to handle the custom styling of the `UISearchController`
* Change the empty state behaviour, as the logic is now the other way around, because we hide the empty view and not the table view
* Use the `TitleLabel` class for the empty state label
* Add separate files for some `MovieViewController` extensions
* Use large titles for movie lists (not in movie and settings detail and search)

Linked to issue #20.

Initial | Scrolled down | Searching
---- | ---- | ----
![simulator screen shot - iphone x - 2018-07-17 at 21 38 56](https://user-images.githubusercontent.com/26111180/42841541-b2fd29fc-8a0a-11e8-9978-ac45d356dc62.png)|![simulator screen shot - iphone x - 2018-07-17 at 21 39 00](https://user-images.githubusercontent.com/26111180/42841542-b31bdcf8-8a0a-11e8-92d4-7b12cbd02d2d.png)|![simulator screen shot - iphone x - 2018-07-17 at 21 39 06](https://user-images.githubusercontent.com/26111180/42841543-b33cb0ea-8a0a-11e8-8578-1321ca1341d0.png)
