### PR TITLE
Fix infinite loop

### DIFF
--- a/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
+++ b/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
@@ -299,6 +299,7 @@ class MovieDetailViewController: UIViewController {
             guard case let .success(detailedMovie) = result else { return }
 
             detailedMovie.poster = movie.poster
+            self.movie = .network(detailedMovie)
             self.setupUI(for: detailedMovie)
         }
     }

--- a/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
+++ b/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
@@ -299,7 +299,6 @@ class MovieDetailViewController: UIViewController {
             guard case let .success(detailedMovie) = result else { return }
 
             detailedMovie.poster = movie.poster
-            self.movie = .network(detailedMovie)
             self.setupUI(for: detailedMovie)
         }
     }

--- a/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
+++ b/Cineaste/ViewController/MovieDetail/MovieDetailViewController.swift
@@ -64,10 +64,13 @@ class MovieDetailViewController: UIViewController {
             case .stored(let storedMovie):
                 setupUI(for: storedMovie)
             case .network(let networkMovie):
-                loadDetails(for: networkMovie)
+                if !detailsLoaded {
+                    loadDetails(for: networkMovie)
+                }
             }
         }
     }
+    private var detailsLoaded = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -299,6 +302,7 @@ class MovieDetailViewController: UIViewController {
             guard case let .success(detailedMovie) = result else { return }
 
             detailedMovie.poster = movie.poster
+            self.detailsLoaded = true
             self.movie = .network(detailedMovie)
             self.setupUI(for: detailedMovie)
         }


### PR DESCRIPTION
## Description

Fixes an infinite loop. Currently, the `MovieDetailViewController` does the following when being used from the search:

1. Set a `.network(Movie)`. The property observer here calls out to the network to load more details
2. Load more details about the movie. This re-sets the `.network(Movie)` and goes back to step 1.

Luckily, the Foundation URL loading mechanism caches this, preventing the API rate limit from being triggered. But this loop is pretty heavy on CPU (and the phone battery) and leaks the `MovieDetailViewController`.

To fix the loop, there is now a flag to tell if the details are loaded already.