### PR TITLE
Fix: Disable Smart Quotes in search bar

### DIFF
--- a/Cineaste/Custom UI/SearchController.swift
+++ b/Cineaste/Custom UI/SearchController.swift
@@ -34,6 +34,8 @@ class SearchController: UISearchController {
         backgroundview.backgroundColor = .basicWhite
         backgroundview.layer.cornerRadius = 10
         backgroundview.clipsToBounds = true
+
+        searchBar.smartQuotesType = .no
     }
 
 }


### PR DESCRIPTION
This prevents smart quotes (’) from being used in the search. Otherwise, the search doesn't yield any results.

## Steps to reproduce
1. Tap the "+" icon to get to "Add Movie"
2. Tap the search bar
3. Change to a *German keyboard*
3. Enter "Child's Play" by using the keyboard (don't copy-paste!)

### Observed results
The search bar reads "Child’s Play" (with a smart single-quote). The list is empty, since there are no search results.

### Expected behaviour
The list should show search results, since the search term "Child's Play" (_without_ a smart single-quote) matches some movies.

## Screenshots

### Before
![1-smartQuotesType-default](https://user-images.githubusercontent.com/1681085/61187470-02c4c800-a661-11e9-8dcb-5493e83a5949.PNG)

### After
![2-smartQuotesType-no](https://user-images.githubusercontent.com/1681085/61187469-02c4c800-a661-11e9-8d37-d588d10643ed.PNG)