### PR TITLE
Fix: Reload username row without animation

### DIFF
--- a/Cineaste/ViewController/Settings/SettingsViewController+UITableView.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController+UITableView.swift
@@ -33,7 +33,7 @@ extension SettingsViewController {
             let alert = UsernameAlert.askForUsernameAlertController(
                 presenter: self,
                 onSave: {
-                    tableView.reloadRows(at: [indexPath], with: .automatic)
+                    self.reloadUsernameCell()
                 },
                 onCancel: {
                     tableView.deselectRow(at: indexPath, animated: true)

--- a/Cineaste/ViewController/Settings/SettingsViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController.swift
@@ -41,9 +41,7 @@ class SettingsViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        guard let rowForUsername = settings.firstIndex(of: SettingItem.name) else { return }
-        let indexPath = IndexPath(row: rowForUsername, section: 0)
-        tableView.reloadRows(at: [indexPath], with: .none)
+        reloadUsernameCell()
     }
 
     override func viewDidLayoutSubviews() {
@@ -79,6 +77,12 @@ class SettingsViewController: UITableViewController {
 }
 
 extension SettingsViewController {
+    func reloadUsernameCell() {
+        guard let rowForUsername = settings.firstIndex(of: SettingItem.name) else { return }
+        let indexPath = IndexPath(row: rowForUsername, section: 0)
+        tableView.reloadRows(at: [indexPath], with: .none)
+    }
+
     func importMovies() {
         let documentPickerVC = UIDocumentPickerViewController(
             documentTypes: [String.exportMoviesFileUTI],

--- a/Cineaste/ViewController/Settings/SettingsViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController.swift
@@ -79,13 +79,9 @@ class SettingsViewController: UITableViewController {
 extension SettingsViewController {
     func reloadUsernameCell() {
         UIView.performWithoutAnimation {
-            let tableViewOffset = tableView.contentOffset
-
             guard let rowForUsername = settings.firstIndex(of: SettingItem.name) else { return }
             let indexPath = IndexPath(row: rowForUsername, section: 0)
             tableView.reloadRows(at: [indexPath], with: .none)
-
-            tableView.contentOffset = tableViewOffset
         }
     }
 

--- a/Cineaste/ViewController/Settings/SettingsViewController.swift
+++ b/Cineaste/ViewController/Settings/SettingsViewController.swift
@@ -78,9 +78,15 @@ class SettingsViewController: UITableViewController {
 
 extension SettingsViewController {
     func reloadUsernameCell() {
-        guard let rowForUsername = settings.firstIndex(of: SettingItem.name) else { return }
-        let indexPath = IndexPath(row: rowForUsername, section: 0)
-        tableView.reloadRows(at: [indexPath], with: .none)
+        UIView.performWithoutAnimation {
+            let tableViewOffset = tableView.contentOffset
+
+            guard let rowForUsername = settings.firstIndex(of: SettingItem.name) else { return }
+            let indexPath = IndexPath(row: rowForUsername, section: 0)
+            tableView.reloadRows(at: [indexPath], with: .none)
+
+            tableView.contentOffset = tableViewOffset
+        }
     }
 
     func importMovies() {


### PR DESCRIPTION
This branch makes sure that the "More" (settings) table view doesn't scroll to some position, but rather stays in place.

## Steps to reproduce

0. Start the app on an on where the "More" table view is scrollable
1. From the tab bar, select "More"
2. Scroll to the very bottom of the table view
3. From the tab bar, select something else, e. g. "Watchlist"
4. Again, tap "More"

### Before
After appearing, the table view shows a scrolling animation.

### After
With these changes, the table view doesn't show that scrolling animation anymore.