### PR TITLE
Remove NEARBY_KEY that's no longer required

### DIFF
--- a/Cineaste/Keys.xcassets/ApiKeys.dataset/apikey.plist
+++ b/Cineaste/Keys.xcassets/ApiKeys.dataset/apikey.plist
@@ -4,7 +4,5 @@
 <dict>
 	<key>MOVIEDB_KEY</key>
 	<string></string>
-	<key>NEARBY_KEY</key>
-	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

In perhaps the smallest PR this repo has seen, this removes the `NEARBY_KEY` from the `apikey.plist` file, as the feature that used to require this key is no longer around.