### PR TITLE
Pin Ruby Version in Gemfile and update Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+ruby '2.7.2'
 
 gem "fastlane"
 gem "xcode-install"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     artifactory (3.0.15)
     atomos (0.1.3)
-    aws-eventstream (1.1.0)
-    aws-partitions (1.429.0)
-    aws-sdk-core (3.112.0)
+    aws-eventstream (1.1.1)
+    aws-partitions (1.431.0)
+    aws-sdk-core (3.112.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -20,7 +20,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.2.2)
+    aws-sigv4 (1.2.3)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.0.3)
@@ -47,7 +47,7 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    fastimage (2.2.2)
+    fastimage (2.2.3)
     fastlane (2.176.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
@@ -123,7 +123,7 @@ GEM
       google-cloud-core (~> 1.2)
       googleauth (~> 0.9)
       mini_mime (~> 1.0)
-    googleauth (0.15.1)
+    googleauth (0.16.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -158,7 +158,7 @@ GEM
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
     security (0.1.3)
-    signet (0.14.1)
+    signet (0.15.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
@@ -201,6 +201,9 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   xcode-install
+
+RUBY VERSION
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
## Description

As there are often issues with different local ruby versions and gems, I pinned the ruby version, so it's clear when updating the dependencies locally, that this ruby version should be used.